### PR TITLE
Fixed usage with module imports

### DIFF
--- a/dist/redis-client.provider.d.ts
+++ b/dist/redis-client.provider.d.ts
@@ -1,5 +1,5 @@
-import * as Redis from "ioredis";
-import { RedisModuleOptions, RedisModuleAsyncOptions } from "./redis.interface";
+import * as Redis from 'ioredis';
+import { RedisModuleAsyncOptions, RedisModuleOptions } from './redis.interface';
 export declare class RedisClientError extends Error {
 }
 export interface RedisClient {

--- a/dist/redis-client.provider.js
+++ b/dist/redis-client.provider.js
@@ -1,8 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const Redis = require("ioredis");
-const redis_constants_1 = require("./redis.constants");
 const uuid = require("uuid");
+const redis_constants_1 = require("./redis.constants");
 class RedisClientError extends Error {
 }
 exports.RedisClientError = RedisClientError;
@@ -12,7 +12,7 @@ exports.createClient = () => ({
         const clients = new Map();
         const defaultKey = uuid();
         if (Array.isArray(options)) {
-            for (let o of options) {
+            for (const o of options) {
                 if (o.name) {
                     if (clients.has(o.name)) {
                         throw new RedisClientError(`client ${o.name} is exists`);
@@ -31,13 +31,15 @@ exports.createClient = () => ({
             clients.set(defaultKey, new Redis(options));
         }
         return {
-            defaultKey, clients, size: clients.size
+            defaultKey,
+            clients,
+            size: clients.size,
         };
     },
-    inject: [redis_constants_1.REDIS_MODULE_OPTIONS]
+    inject: [redis_constants_1.REDIS_MODULE_OPTIONS],
 });
 exports.createAsyncClientOptions = (options) => ({
     provide: redis_constants_1.REDIS_MODULE_OPTIONS,
     useFactory: options.useFactory,
-    inject: options.inject
+    inject: options.inject,
 });

--- a/dist/redis-core.module.d.ts
+++ b/dist/redis-core.module.d.ts
@@ -1,6 +1,6 @@
 import { DynamicModule } from '@nestjs/common';
 import { RedisModuleAsyncOptions, RedisModuleOptions } from './redis.interface';
-export declare class RedisModule {
+export declare class RedisCoreModule {
     static register(options: RedisModuleOptions | RedisModuleOptions[]): DynamicModule;
     static forRootAsync(options: RedisModuleAsyncOptions): DynamicModule;
 }

--- a/dist/redis-core.module.js
+++ b/dist/redis-core.module.js
@@ -1,0 +1,41 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var RedisCoreModule_1;
+const common_1 = require("@nestjs/common");
+const redis_client_provider_1 = require("./redis-client.provider");
+const redis_constants_1 = require("./redis.constants");
+const redis_service_1 = require("./redis.service");
+let RedisCoreModule = RedisCoreModule_1 = class RedisCoreModule {
+    static register(options) {
+        return {
+            module: RedisCoreModule_1,
+            providers: [
+                redis_client_provider_1.createClient(),
+                { provide: redis_constants_1.REDIS_MODULE_OPTIONS, useValue: options },
+            ],
+            exports: [redis_service_1.RedisService],
+        };
+    }
+    static forRootAsync(options) {
+        return {
+            module: RedisCoreModule_1,
+            imports: options.imports,
+            providers: [redis_client_provider_1.createClient(), redis_client_provider_1.createAsyncClientOptions(options)],
+            exports: [redis_service_1.RedisService],
+        };
+    }
+};
+RedisCoreModule = RedisCoreModule_1 = __decorate([
+    common_1.Global(),
+    common_1.Module({
+        providers: [redis_service_1.RedisService],
+        exports: [redis_service_1.RedisService],
+    })
+], RedisCoreModule);
+exports.RedisCoreModule = RedisCoreModule;

--- a/dist/redis.module.js
+++ b/dist/redis.module.js
@@ -8,37 +8,22 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 Object.defineProperty(exports, "__esModule", { value: true });
 var RedisModule_1;
 const common_1 = require("@nestjs/common");
-const redis_constants_1 = require("./redis.constants");
-const redis_service_1 = require("./redis.service");
-const redis_client_provider_1 = require("./redis-client.provider");
+const redis_core_module_1 = require("./redis-core.module");
 let RedisModule = RedisModule_1 = class RedisModule {
     static register(options) {
         return {
             module: RedisModule_1,
-            providers: [
-                redis_client_provider_1.createClient(),
-                { provide: redis_constants_1.REDIS_MODULE_OPTIONS, useValue: options }
-            ],
-            exports: [redis_service_1.RedisService]
+            imports: [redis_core_module_1.RedisCoreModule.register(options)],
         };
     }
     static forRootAsync(options) {
         return {
             module: RedisModule_1,
-            imports: options.imports,
-            providers: [
-                redis_client_provider_1.createClient(),
-                redis_client_provider_1.createAsyncClientOptions(options),
-            ],
-            exports: [redis_service_1.RedisService]
+            imports: [redis_core_module_1.RedisCoreModule.forRootAsync(options)],
         };
     }
 };
 RedisModule = RedisModule_1 = __decorate([
-    common_1.Global(),
-    common_1.Module({
-        providers: [redis_service_1.RedisService],
-        exports: [redis_service_1.RedisService]
-    })
+    common_1.Module({})
 ], RedisModule);
 exports.RedisModule = RedisModule;

--- a/lib/redis-client.provider.ts
+++ b/lib/redis-client.provider.ts
@@ -1,47 +1,49 @@
-import * as Redis from "ioredis"
+import * as Redis from 'ioredis';
+import * as uuid from 'uuid';
+
 import { REDIS_CLIENT, REDIS_MODULE_OPTIONS } from './redis.constants';
-import { RedisModuleOptions, RedisModuleAsyncOptions } from "./redis.interface";
-import * as uuid from 'uuid'
+import { RedisModuleAsyncOptions, RedisModuleOptions } from './redis.interface';
 
 export class RedisClientError extends Error {}
 export interface RedisClient {
-  defaultKey:string,
-  clients: Map<string, Redis.Redis>,
-  size:number
+  defaultKey: string;
+  clients: Map<string, Redis.Redis>;
+  size: number;
 }
 
 export const createClient = () => ({
   provide: REDIS_CLIENT,
-  useFactory:(options: RedisModuleOptions | RedisModuleOptions[]) => {
-    const clients = new Map<string,Redis.Redis>()
-    const defaultKey = uuid()
-    if(Array.isArray(options)) {
-      for(let o of options) {
-        if(o.name) {
-          if(clients.has(o.name)) {
-            throw new RedisClientError(`client ${o.name} is exists`)
+  useFactory: (options: RedisModuleOptions | RedisModuleOptions[]) => {
+    const clients = new Map<string, Redis.Redis>();
+    const defaultKey = uuid();
+    if (Array.isArray(options)) {
+      for (const o of options) {
+        if (o.name) {
+          if (clients.has(o.name)) {
+            throw new RedisClientError(`client ${o.name} is exists`);
           }
-          clients.set(o.name, new Redis(o))
+          clients.set(o.name, new Redis(o));
         } else {
-          if(clients.has(defaultKey)) {
-            throw new RedisClientError('default client is exists')
+          if (clients.has(defaultKey)) {
+            throw new RedisClientError('default client is exists');
           }
-          clients.set(defaultKey, new Redis(o))
+          clients.set(defaultKey, new Redis(o));
         }
       }
     } else {
-      clients.set(defaultKey,new Redis(options))
+      clients.set(defaultKey, new Redis(options));
     }
     return {
-      defaultKey,clients,size:clients.size
-    }
+      defaultKey,
+      clients,
+      size: clients.size,
+    };
   },
-  inject:[REDIS_MODULE_OPTIONS]
-})
+  inject: [REDIS_MODULE_OPTIONS],
+});
 
-export const createAsyncClientOptions = (options:RedisModuleAsyncOptions) => ({
+export const createAsyncClientOptions = (options: RedisModuleAsyncOptions) => ({
   provide: REDIS_MODULE_OPTIONS,
   useFactory: options.useFactory,
-  inject: options.inject
-})
-  
+  inject: options.inject,
+});

--- a/lib/redis-core.module.ts
+++ b/lib/redis-core.module.ts
@@ -1,0 +1,38 @@
+import { DynamicModule, Global, Module } from '@nestjs/common';
+import { RedisModuleAsyncOptions, RedisModuleOptions } from './redis.interface';
+import {
+  createAsyncClientOptions,
+  createClient,
+} from './redis-client.provider';
+
+import { REDIS_MODULE_OPTIONS } from './redis.constants';
+import { RedisService } from './redis.service';
+
+@Global()
+@Module({
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class RedisCoreModule {
+  static register(
+    options: RedisModuleOptions | RedisModuleOptions[],
+  ): DynamicModule {
+    return {
+      module: RedisCoreModule,
+      providers: [
+        createClient(),
+        { provide: REDIS_MODULE_OPTIONS, useValue: options },
+      ],
+      exports: [RedisService],
+    };
+  }
+
+  static forRootAsync(options: RedisModuleAsyncOptions): DynamicModule {
+    return {
+      module: RedisCoreModule,
+      imports: options.imports,
+      providers: [createClient(), createAsyncClientOptions(options)],
+      exports: [RedisService],
+    };
+  }
+}

--- a/lib/redis.interface.ts
+++ b/lib/redis.interface.ts
@@ -2,10 +2,15 @@ import { ModuleMetadata } from '@nestjs/common/interfaces';
 import { RedisOptions } from 'ioredis';
 
 export interface RedisModuleOptions extends RedisOptions {
-  name?: string
+  name?: string;
 }
 
-export interface RedisModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
-  useFactory?: (...args: any[]) => RedisModuleOptions | RedisModuleOptions[] | Promise<RedisModuleOptions> | Promise<RedisModuleOptions[]>,
+export interface RedisModuleAsyncOptions
+  extends Pick<ModuleMetadata, 'imports'> {
+  useFactory?: (...args: any[]) =>
+    | RedisModuleOptions
+    | RedisModuleOptions[]
+    | Promise<RedisModuleOptions>
+    | Promise<RedisModuleOptions[]>;
   inject?: any[];
 }

--- a/lib/redis.module.ts
+++ b/lib/redis.module.ts
@@ -1,35 +1,23 @@
-import { DynamicModule, Module, Global } from '@nestjs/common';
-import { RedisModuleOptions, RedisModuleAsyncOptions } from './redis.interface';
-import { REDIS_MODULE_OPTIONS } from './redis.constants';
-import { RedisService } from './redis.service';
-import { createClient, createAsyncClientOptions } from './redis-client.provider';
+import { DynamicModule, Module } from '@nestjs/common';
+import { RedisModuleAsyncOptions, RedisModuleOptions } from './redis.interface';
 
-@Global()
-@Module({
-  providers:[RedisService],
-  exports:[RedisService]
-})
+import { RedisCoreModule } from './redis-core.module';
+
+@Module({})
 export class RedisModule {
-  static register(options:RedisModuleOptions|RedisModuleOptions[]): DynamicModule {
+  static register(
+    options: RedisModuleOptions | RedisModuleOptions[],
+  ): DynamicModule {
     return {
       module: RedisModule,
-      providers: [
-        createClient(),
-        { provide: REDIS_MODULE_OPTIONS, useValue:options}
-      ],
-      exports: [RedisService]
-    }
+      imports: [RedisCoreModule.register(options)],
+    };
   }
 
-  static forRootAsync(options: RedisModuleAsyncOptions) : DynamicModule {
+  static forRootAsync(options: RedisModuleAsyncOptions): DynamicModule {
     return {
       module: RedisModule,
-      imports: options.imports,
-      providers: [
-        createClient(),
-        createAsyncClientOptions(options),
-      ],
-      exports: [RedisService]
-    }
+      imports: [RedisCoreModule.forRootAsync(options)],
+    };
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/kyknow/nestjs-redis"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "build": "rimraf dist && tsc -p tsconfig.json",
     "precommit": "lint-staged",
     "prepublish:npm": "yarn run build",
     "publish:npm": "yarn publish --access public",
@@ -31,6 +31,7 @@
     "@types/node": "^10.7.1",
     "cz-conventional-changelog": "^2.1.0",
     "jest": "^23.6.0",
+    "rimraf": "^2.6.3",
     "ts-jest": "^23.10.5",
     "typescript": "^2.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/ioredis": "^4.0.4",
     "@types/uuid": "^3.4.4",
     "ioredis": "^4.2.0",
+    "reflect-metadata": "^0.1.12",
     "rxjs": "^6.2.2",
     "uuid": "^3.3.2"
   },


### PR DESCRIPTION
Original version had issue for this case:

we have app.module.ts having 
```
  imports: [
  RedisModule.register(ConfigService.getRedisConfig()),
  AuthModule,
  ...
]
```
and we have auth.module having 
```
imports: [
  RedisModule,
]
```
It raised error while trying to resolve RedisService dependencies in the auth module.

This PR resolves this cases (same way as in nestjs-typeorm). Also resolved build for Windows, and code formatted to meet TSLint requirements