### PR TITLE
fix(connection): close connections onModuleDestroy

### DIFF
--- a/dist/redis-core.module.d.ts
+++ b/dist/redis-core.module.d.ts
@@ -7,5 +7,5 @@ export declare class RedisCoreModule implements OnModuleDestroy {
     constructor(options: RedisModuleOptions | RedisModuleOptions[], moduleRef: ModuleRef);
     static register(options: RedisModuleOptions | RedisModuleOptions[]): DynamicModule;
     static forRootAsync(options: RedisModuleAsyncOptions): DynamicModule;
-    onModuleDestroy(): Promise<void>;
+    onModuleDestroy(): void;
 }

--- a/dist/redis-core.module.d.ts
+++ b/dist/redis-core.module.d.ts
@@ -1,6 +1,11 @@
-import { DynamicModule } from '@nestjs/common';
+import { DynamicModule, OnModuleDestroy } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 import { RedisModuleAsyncOptions, RedisModuleOptions } from './redis.interface';
-export declare class RedisCoreModule {
+export declare class RedisCoreModule implements OnModuleDestroy {
+    private readonly options;
+    private readonly moduleRef;
+    constructor(options: RedisModuleOptions | RedisModuleOptions[], moduleRef: ModuleRef);
     static register(options: RedisModuleOptions | RedisModuleOptions[]): DynamicModule;
     static forRootAsync(options: RedisModuleAsyncOptions): DynamicModule;
+    onModuleDestroy(): Promise<void>;
 }

--- a/dist/redis-core.module.js
+++ b/dist/redis-core.module.js
@@ -11,14 +11,6 @@ var __metadata = (this && this.__metadata) || function (k, v) {
 var __param = (this && this.__param) || function (paramIndex, decorator) {
     return function (target, key) { decorator(target, key, paramIndex); }
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 var RedisCoreModule_1;
 const common_1 = require("@nestjs/common");
@@ -50,23 +42,21 @@ let RedisCoreModule = RedisCoreModule_1 = class RedisCoreModule {
         };
     }
     onModuleDestroy() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const closeConnection = ({ clients, defaultKey }) => (options) => __awaiter(this, void 0, void 0, function* () {
-                const name = options.name || defaultKey;
-                const client = clients.get(name);
-                if (client && !options.keepAlive) {
-                    yield client.disconnect();
-                }
-            });
-            const redisClient = this.moduleRef.get(redis_constants_1.REDIS_CLIENT);
-            const closeClientConnection = closeConnection(redisClient);
-            if (Array.isArray(this.options)) {
-                yield Promise.all(this.options.map(closeClientConnection));
+        const closeConnection = ({ clients, defaultKey }) => options => {
+            const name = options.name || defaultKey;
+            const client = clients.get(name);
+            if (client && !options.keepAlive) {
+                client.disconnect();
             }
-            else {
-                yield closeClientConnection(this.options);
-            }
-        });
+        };
+        const redisClient = this.moduleRef.get(redis_constants_1.REDIS_CLIENT);
+        const closeClientConnection = closeConnection(redisClient);
+        if (Array.isArray(this.options)) {
+            this.options.forEach(closeClientConnection);
+        }
+        else {
+            closeClientConnection(this.options);
+        }
     }
 };
 RedisCoreModule = RedisCoreModule_1 = __decorate([

--- a/dist/redis-core.module.js
+++ b/dist/redis-core.module.js
@@ -5,13 +5,32 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __param = (this && this.__param) || function (paramIndex, decorator) {
+    return function (target, key) { decorator(target, key, paramIndex); }
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 var RedisCoreModule_1;
 const common_1 = require("@nestjs/common");
+const core_1 = require("@nestjs/core");
 const redis_client_provider_1 = require("./redis-client.provider");
 const redis_constants_1 = require("./redis.constants");
 const redis_service_1 = require("./redis.service");
 let RedisCoreModule = RedisCoreModule_1 = class RedisCoreModule {
+    constructor(options, moduleRef) {
+        this.options = options;
+        this.moduleRef = moduleRef;
+    }
     static register(options) {
         return {
             module: RedisCoreModule_1,
@@ -30,12 +49,33 @@ let RedisCoreModule = RedisCoreModule_1 = class RedisCoreModule {
             exports: [redis_service_1.RedisService],
         };
     }
+    onModuleDestroy() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const closeConnection = ({ clients, defaultKey }) => (options) => __awaiter(this, void 0, void 0, function* () {
+                const name = options.name || defaultKey;
+                const client = clients.get(name);
+                if (client && !options.keepAlive) {
+                    yield client.disconnect();
+                }
+            });
+            const redisClient = this.moduleRef.get(redis_constants_1.REDIS_CLIENT);
+            const closeClientConnection = closeConnection(redisClient);
+            if (Array.isArray(this.options)) {
+                yield Promise.all(this.options.map(closeClientConnection));
+            }
+            else {
+                yield closeClientConnection(this.options);
+            }
+        });
+    }
 };
 RedisCoreModule = RedisCoreModule_1 = __decorate([
     common_1.Global(),
     common_1.Module({
         providers: [redis_service_1.RedisService],
         exports: [redis_service_1.RedisService],
-    })
+    }),
+    __param(0, common_1.Inject(redis_constants_1.REDIS_MODULE_OPTIONS)),
+    __metadata("design:paramtypes", [Object, core_1.ModuleRef])
 ], RedisCoreModule);
 exports.RedisCoreModule = RedisCoreModule;

--- a/lib/redis-core.module.ts
+++ b/lib/redis-core.module.ts
@@ -50,13 +50,13 @@ export class RedisCoreModule implements OnModuleDestroy {
     };
   }
 
-  async onModuleDestroy() {
-    const closeConnection = ({ clients, defaultKey }) => async options => {
+  onModuleDestroy() {
+    const closeConnection = ({ clients, defaultKey }) => options => {
       const name = options.name || defaultKey;
       const client = clients.get(name);
 
       if (client && !options.keepAlive) {
-        await client.disconnect();
+        client.disconnect();
       }
     };
 
@@ -64,9 +64,9 @@ export class RedisCoreModule implements OnModuleDestroy {
     const closeClientConnection = closeConnection(redisClient);
 
     if (Array.isArray(this.options)) {
-      await Promise.all(this.options.map(closeClientConnection));
+      this.options.forEach(closeClientConnection);
     } else {
-      await closeClientConnection(this.options);
+      closeClientConnection(this.options);
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@nestjs/common": "6.3.1",
+    "@nestjs/core": "^6.6.7",
     "@types/ioredis": "^4.0.4",
     "@types/uuid": "^3.4.4",
     "ioredis": "^4.2.0",


### PR DESCRIPTION
Currently, module does not close connections after `app.close()` [nestjs lifecycle doc](https://docs.nestjs.com/fundamentals/lifecycle-events), this leads to unexpected behavior when test suite is unable to exit clean and errors like the following:
```
Jest did not exit one second after the test run has completed.
This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

This PR adds onModuleDestroy lifecycle event handler, which closes connection if `keepAlive` option is not specified, hence app can gracefully shutdown.