### PR TITLE
Custom Client Factory

### DIFF
--- a/lib/redis-core.module.ts
+++ b/lib/redis-core.module.ts
@@ -11,9 +11,10 @@ import {
   createAsyncClientOptions,
   createClient,
   RedisClient,
+  RedisClients,
 } from './redis-client.provider';
 
-import { REDIS_MODULE_OPTIONS, REDIS_CLIENT } from './redis.constants';
+import { REDIS_MODULE_OPTIONS, REDIS_CLIENTS } from './redis.constants';
 import { RedisService } from './redis.service';
 
 @Global()
@@ -60,7 +61,7 @@ export class RedisCoreModule implements OnModuleDestroy {
       }
     };
 
-    const redisClient = this.moduleRef.get<RedisClient>(REDIS_CLIENT);
+    const redisClient = this.moduleRef.get<RedisClients>(REDIS_CLIENTS);
     const closeClientConnection = closeConnection(redisClient);
 
     if (Array.isArray(this.options)) {

--- a/lib/redis.constants.ts
+++ b/lib/redis.constants.ts
@@ -1,2 +1,2 @@
 export const REDIS_MODULE_OPTIONS = Symbol('REDIS_MODULE_OPTIONS');
-export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
+export const REDIS_CLIENTS = Symbol('REDIS_CLIENTS');

--- a/lib/redis.interface.ts
+++ b/lib/redis.interface.ts
@@ -1,10 +1,12 @@
 import { ModuleMetadata } from '@nestjs/common/interfaces';
 import { Redis, RedisOptions } from 'ioredis';
+import { RedisClient, RedisClients } from './redis-client.provider';
 
 export interface RedisModuleOptions extends RedisOptions {
   name?: string;
   url?: string;
-  onClientReady?(client: Redis): Promise<void>;
+  onClientReady?(client: RedisClient): Promise<void>;
+  clientFactory?: (options: RedisModuleOptions) => RedisClient;
 }
 
 export interface RedisModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {

--- a/lib/redis.service.ts
+++ b/lib/redis.service.ts
@@ -1,25 +1,24 @@
 import { Injectable, Inject } from '@nestjs/common';
-import { REDIS_CLIENT } from './redis.constants';
-import * as Redis from 'ioredis';
-import { RedisClient, RedisClientError } from './redis-client.provider';
+import { REDIS_CLIENTS } from './redis.constants';
+import { RedisClient, RedisClientError, RedisClients } from './redis-client.provider';
 
 @Injectable()
 export class RedisService {
   constructor(
-    @Inject(REDIS_CLIENT) private readonly redisClient: RedisClient,
+    @Inject(REDIS_CLIENTS) private readonly redisClients: RedisClients,
   ) {}
 
-  getClient(name?: string): Redis.Redis {
+  getClient(name?: string): RedisClient {
     if (!name) {
-      name = this.redisClient.defaultKey;
+      name = this.redisClients.defaultKey;
     }
-    if (!this.redisClient.clients.has(name)) {
+    if (!this.redisClients.clients.has(name)) {
       throw new RedisClientError(`client ${name} does not exist`);
     }
-    return this.redisClient.clients.get(name);
+    return this.redisClients.clients.get(name);
   }
 
-  getClients(): Map<string, Redis.Redis> {
-    return this.redisClient.clients;
+  getClients(): Map<string, RedisClient> {
+    return this.redisClients.clients;
   }
 }


### PR DESCRIPTION
This PR introduces the abiilty to provide a custom instance of cache client. The intended purpose is to wrap IORedis instance in your custom instance, for example not to expose all public methods, override the default or provide custom ones. 

The most radical use case would be also to replace IORedis with another Redis lib (but at some level of compatibility), so it makes the whole library, not vendor locked in the future.

On the type/semantic level, it changed the naming of the Clients Pool from misguiding RedisClient to RedisClients.